### PR TITLE
Multistream Encoding Conversion

### DIFF
--- a/include/camera_aravis/camera_aravis_nodelet.h
+++ b/include/camera_aravis/camera_aravis_nodelet.h
@@ -315,7 +315,7 @@ protected:
   std::vector<std::string> stream_names_;
   std::vector<CameraBufferPool::Ptr> p_buffer_pools_;
   int32_t acquire_ = 0;
-  ConversionFunction convert_format;
+  std::vector<ConversionFunction> convert_formats;
 };
 
 } // end namespace camera_aravis

--- a/src/camera_aravis_nodelet.cpp
+++ b/src/camera_aravis_nodelet.cpp
@@ -831,33 +831,30 @@ void CameraAravisNodelet::spawnStream()
     pnh.getParam("guid", guid);
   }
 
-  if (spawning_)
-  {
-    for(int i = 0; i < num_streams_; i++) {
-      while (true) {
+  for(int i = 0; i < num_streams_; i++) {
+    while (spawning_) {
+      arv_camera_gv_select_stream_channel(p_camera_, i);
+      p_streams_[i] = arv_camera_create_stream(p_camera_, NULL, NULL);
+
+      if (p_streams_[i])
+      {
+        // Load up some buffers.
         arv_camera_gv_select_stream_channel(p_camera_, i);
-        p_streams_[i] = arv_camera_create_stream(p_camera_, NULL, NULL);
+        const gint n_bytes_payload_stream_ = arv_camera_get_payload(p_camera_);
 
-        if (p_streams_[i])
+        p_buffer_pools_[i].reset(new CameraBufferPool(p_streams_[i], n_bytes_payload_stream_, 10));
+
+        if (arv_camera_is_gv_device(p_camera_))
         {
-          // Load up some buffers.
-          arv_camera_gv_select_stream_channel(p_camera_, i);
-          const gint n_bytes_payload_stream_ = arv_camera_get_payload(p_camera_);
-
-          p_buffer_pools_[i].reset(new CameraBufferPool(p_streams_[i], n_bytes_payload_stream_, 10));
-
-          if (arv_camera_is_gv_device(p_camera_))
-          {
-            tuneGvStream(reinterpret_cast<ArvGvStream*>(p_streams_[i]));
-          }
-          break;
+          tuneGvStream(reinterpret_cast<ArvGvStream*>(p_streams_[i]));
         }
-        else
-        {
-          ROS_WARN("Stream %i: Could not create image stream for %s.  Retrying...", i, guid.c_str());
-          ros::Duration(1.0).sleep();
-          ros::spinOnce();
-        }
+        break;
+      }
+      else
+      {
+        ROS_WARN("Stream %i: Could not create image stream for %s.  Retrying...", i, guid.c_str());
+        ros::Duration(1.0).sleep();
+        ros::spinOnce();
       }
     }
   }

--- a/src/camera_aravis_nodelet.cpp
+++ b/src/camera_aravis_nodelet.cpp
@@ -816,7 +816,7 @@ void CameraAravisNodelet::onInit()
   if (use_ptp_stamp_)
     resetPtpClock();
 
-  // spwan camera stream in thread, so onInit() is not blocked
+  // spawn camera stream in thread, so onInit() is not blocked
   spawning_ = true;
   spawn_stream_thread_ = std::thread(&CameraAravisNodelet::spawnStream, this);
 }
@@ -831,7 +831,7 @@ void CameraAravisNodelet::spawnStream()
     pnh.getParam("guid", guid);
   }
 
-  while (spawning_)
+  if (spawning_)
   {
     for(int i = 0; i < num_streams_; i++) {
       while (true) {


### PR DESCRIPTION
Hi Thomas,

in this PR I add a fix to pass on the correct encoding in the header of the additional streams of multisource cameras.
Included are also the commits from PR #6.
To handle multiple encodings I changed `convert_format` to a vector (see 4220a5531e9a0c607f94c8d8ee0648659b56fa7b).

Best regards,
Peter