### PR TITLE
Pr extended camera info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ generate_dynamic_reconfigure_options(cfg/CameraAravis.cfg)
 add_message_files(
    FILES
    CameraAutoInfo.msg
+   ExtendedCameraInfo.msg
 )
 
 add_service_files(
@@ -41,6 +42,7 @@ add_service_files(
 generate_messages(
    DEPENDENCIES
    std_msgs
+   sensor_msgs
 )
 
 catkin_package(

--- a/include/camera_aravis/camera_aravis_nodelet.h
+++ b/include/camera_aravis/camera_aravis_nodelet.h
@@ -63,6 +63,7 @@ extern "C" {
 #include <tf2_ros/transform_broadcaster.h>
 #include <camera_aravis/CameraAravisConfig.h>
 #include <camera_aravis/CameraAutoInfo.h>
+#include <camera_aravis/ExtendedCameraInfo.h>
 
 #include <camera_aravis/get_integer_feature_value.h>
 #include <camera_aravis/set_integer_feature_value.h>
@@ -222,6 +223,9 @@ protected:
   void setAutoMaster(bool value);
   void setAutoSlave(bool value);
 
+  void setExtendedCameraInfo(std::string channel_name, size_t stream_id);
+  void fillExtendedCameraInfoMessage(ExtendedCameraInfo &msg);
+
   // Extra stream options for GigEVision streams.
   void tuneGvStream(ArvGvStream *p_stream);
 
@@ -288,6 +292,7 @@ protected:
 
   std::vector<image_transport::CameraPublisher> cam_pubs_;
   std::vector<std::unique_ptr<camera_info_manager::CameraInfoManager>> p_camera_info_managers_;
+  std::vector<std::unique_ptr<ros::NodeHandle>> p_camera_info_node_handles_;
   std::vector<sensor_msgs::CameraInfoPtr> camera_infos_;
 
   std::unique_ptr<tf2_ros::StaticTransformBroadcaster> p_stb_;
@@ -299,6 +304,9 @@ protected:
   CameraAutoInfo auto_params_;
   ros::Publisher auto_pub_;
   ros::Subscriber auto_sub_;
+
+  boost::recursive_mutex extended_camera_info_mutex_;
+  std::vector<ros::Publisher> extended_camera_info_pubs_;
 
   Config config_;
   Config config_min_;
@@ -347,6 +355,7 @@ protected:
   gint num_streams_;
   std::vector<ArvStream *> p_streams_;
   std::vector<std::string> stream_names_;
+  bool extended_camera_info_;
   std::vector<CameraBufferPool::Ptr> p_buffer_pools_;
   int32_t acquire_ = 0;
   std::vector<ConversionFunction> convert_formats;

--- a/msg/ExtendedCameraInfo.msg
+++ b/msg/ExtendedCameraInfo.msg
@@ -1,0 +1,14 @@
+# Contains the standard sensor_msgs/CameraInfo and additional information about the image acquisition parameters.
+# This includes parameters on the exposure, gain, black level, white balance and device temperature.
+
+sensor_msgs/CameraInfo camera_info # contains a header and calibration parameters
+
+float64 exposure_time # in microseconds
+float64 gain # unit is device-specific
+float64 black_level # unit is device-specific
+
+float64 white_balance_red # unit is device-specific
+float64 white_balance_green # unit is device-specific
+float64 white_balance_blue # unit is device-specific
+
+float64 temperature # in degrees Celsius

--- a/src/camera_aravis_nodelet.cpp
+++ b/src/camera_aravis_nodelet.cpp
@@ -1623,8 +1623,18 @@ void CameraAravisNodelet::newBufferReady(ArvStream *p_stream, CameraAravisNodele
       }
       (*p_can->camera_infos_[stream_id]) = p_can->p_camera_info_managers_[stream_id]->getCameraInfo();
       p_can->camera_infos_[stream_id]->header = msg_ptr->header;
-      p_can->camera_infos_[stream_id]->width = p_can->roi_.width;
-      p_can->camera_infos_[stream_id]->height = p_can->roi_.height;
+      if (p_can->camera_infos_[stream_id]->width == 0 || p_can->camera_infos_[stream_id]->height == 0) {
+        ROS_WARN_STREAM_ONCE(
+            "The fields image_width and image_height seem not to be set in "
+            "the YAML specified by 'camera_info_url' parameter. Please set "
+            "them there, because actual image size and specified image size "
+            "can be different due to the region of interest (ROI) feature. In "
+            "the YAML the image size should be the one on which the camera was "
+            "calibrated. See CameraInfo.msg specification!");
+        p_can->camera_infos_[stream_id]->width = p_can->roi_.width;
+        p_can->camera_infos_[stream_id]->height = p_can->roi_.height;
+      }
+      
 
       p_can->cam_pubs_[stream_id].publish(msg_ptr, p_can->camera_infos_[stream_id]);
 

--- a/src/camera_aravis_nodelet.cpp
+++ b/src/camera_aravis_nodelet.cpp
@@ -584,8 +584,10 @@ void CameraAravisNodelet::onInit()
     p_streams_.push_back(NULL);
     p_buffer_pools_.push_back(CameraBufferPool::Ptr());
     p_camera_info_managers_.push_back(NULL);
+    p_camera_info_node_handles_.push_back(NULL);
     camera_infos_.push_back(sensor_msgs::CameraInfoPtr());
     cam_pubs_.push_back(image_transport::CameraPublisher());
+    extended_camera_info_pubs_.push_back(ros::Publisher());
   }
 
   // Get parameter bounds.
@@ -690,6 +692,9 @@ void CameraAravisNodelet::onInit()
   setAutoMaster(config_.AutoMaster);
   setAutoSlave(config_.AutoSlave);
 
+  // publish an extended camera info message
+  pnh.param<bool>("ExtendedCameraInfo", extended_camera_info_, false);
+
   // should we publish tf transforms to camera optical frame?
   bool pub_tf_optical;
   pnh.param<bool>("publish_tf", pub_tf_optical, false);
@@ -746,9 +751,24 @@ void CameraAravisNodelet::onInit()
 
   for(int i = 0; i < num_streams_; i++) {
     // Start the camerainfo manager.
-    p_camera_info_managers_[i].reset(new camera_info_manager::CameraInfoManager(pnh, stream_names_[i], calib_urls[i]));
+    std::string camera_info_frame_id = config_.frame_id;
+    if(!stream_names_[i].empty())
+      camera_info_frame_id = config_.frame_id + '/' + stream_names_[i];
+
+    // Use separate node handles for CameraInfoManagers when using a Multisource Camera
+    if(!stream_names_[i].empty()) {
+      p_camera_info_node_handles_[i].reset(new ros::NodeHandle(pnh, stream_names_[i]));
+      p_camera_info_managers_[i].reset(new camera_info_manager::CameraInfoManager(*p_camera_info_node_handles_[i], camera_info_frame_id, calib_urls[i]));
+    } else {
+      p_camera_info_managers_[i].reset(new camera_info_manager::CameraInfoManager(pnh, camera_info_frame_id, calib_urls[i]));
+    }
+
+    
     ROS_INFO("Reset %s Camera Info Manager", stream_names_[i].c_str());
     ROS_INFO("%s Calib URL: %s", stream_names_[i].c_str(), calib_urls[i].c_str());
+
+    // publish an ExtendedCameraInfo message
+    setExtendedCameraInfo(stream_names_[i], i);
   }
 
   // update the reconfigure config
@@ -1237,6 +1257,22 @@ void CameraAravisNodelet::setAutoSlave(bool value)
   }
 }
 
+void CameraAravisNodelet::setExtendedCameraInfo(std::string channel_name, size_t stream_id)
+{
+  if (extended_camera_info_)
+  {
+    if (channel_name.empty()) {
+      extended_camera_info_pubs_[stream_id]  = getNodeHandle().advertise<ExtendedCameraInfo>(ros::names::remap("extended_camera_info"), 1, true);
+    } else {
+      extended_camera_info_pubs_[stream_id]  = getNodeHandle().advertise<ExtendedCameraInfo>(ros::names::remap(channel_name + "/extended_camera_info"), 1, true);
+    }
+  }
+  else
+  {
+    extended_camera_info_pubs_[stream_id].shutdown();
+  }
+}
+
 // Extra stream options for GigEVision streams.
 void CameraAravisNodelet::tuneGvStream(ArvGvStream *p_stream)
 {
@@ -1592,14 +1628,25 @@ void CameraAravisNodelet::newBufferReady(ArvStream *p_stream, CameraAravisNodele
 
       p_can->cam_pubs_[stream_id].publish(msg_ptr, p_can->camera_infos_[stream_id]);
 
+      if (p_can->extended_camera_info_) {
+        ExtendedCameraInfo extended_camera_info_msg;
+        p_can->extended_camera_info_mutex_.lock();
+        arv_camera_gv_select_stream_channel(p_can->p_camera_, stream_id);
+        extended_camera_info_msg.camera_info = *(p_can->camera_infos_[stream_id]);
+        p_can->fillExtendedCameraInfoMessage(extended_camera_info_msg);
+        p_can->extended_camera_info_mutex_.unlock();
+        p_can->extended_camera_info_pubs_[stream_id].publish(extended_camera_info_msg);
+      }
+
       // check PTP status, camera cannot recover from "Faulty" by itself
       if (p_can->use_ptp_stamp_)
         p_can->resetPtpClock();
     }
     else
     {
-      ROS_WARN("(%s) Frame error: %s", frame_id.c_str(), szBufferStatusFromInt[arv_buffer_get_status(p_buffer)]);
-
+      if (arv_buffer_get_status(p_buffer) != ARV_BUFFER_STATUS_SUCCESS) {
+        ROS_WARN("(%s) Frame error: %s", frame_id.c_str(), szBufferStatusFromInt[arv_buffer_get_status(p_buffer)]);
+      }
       arv_stream_push_buffer(p_stream, p_buffer);
     }
   }
@@ -1610,6 +1657,83 @@ void CameraAravisNodelet::newBufferReady(ArvStream *p_stream, CameraAravisNodele
     p_can->syncAutoParameters();
     p_can->auto_pub_.publish(p_can->auto_params_);
   }
+}
+
+void CameraAravisNodelet::fillExtendedCameraInfoMessage(ExtendedCameraInfo &msg) 
+{
+  const char *vendor_name = arv_camera_get_vendor_name(p_camera_);
+
+  if (strcmp("Basler", vendor_name) == 0) {
+    msg.exposure_time = arv_device_get_float_feature_value(p_device_, "ExposureTimeAbs");
+  } 
+  else if (implemented_features_["ExposureTime"])
+  {
+    msg.exposure_time = arv_device_get_float_feature_value(p_device_, "ExposureTime");
+  } 
+
+  if (strcmp("Basler", vendor_name) == 0) {
+    msg.gain = static_cast<float>(arv_device_get_integer_feature_value(p_device_, "GainRaw"));
+  }
+  else if (implemented_features_["Gain"])
+  {
+    msg.gain = arv_device_get_float_feature_value(p_device_, "Gain");
+  }
+  if (strcmp("Basler", vendor_name) == 0) {
+    arv_device_set_string_feature_value(p_device_, "BlackLevelSelector", "All");
+    msg.black_level = static_cast<float>(arv_device_get_integer_feature_value(p_device_, "BlackLevelRaw"));
+  } else if (strcmp("JAI Corporation", vendor_name) == 0) {
+    // Reading the black level register for both streams of the JAI FS 3500D takes too long.
+    // The frame rate the drops below 10 fps.
+    msg.black_level = 0;
+  } else {
+    arv_device_set_string_feature_value(p_device_, "BlackLevelSelector", "All");
+    msg.black_level = arv_device_get_float_feature_value(p_device_, "BlackLevel");
+  }
+
+  // White balance as TIS is providing
+  if (strcmp("The Imaging Source Europe GmbH", vendor_name) == 0)
+  {
+    msg.white_balance_red = arv_device_get_integer_feature_value(p_device_, "WhiteBalanceRedRegister") / 255.;
+    msg.white_balance_green = arv_device_get_integer_feature_value(p_device_, "WhiteBalanceGreenRegister") / 255.;
+    msg.white_balance_blue = arv_device_get_integer_feature_value(p_device_, "WhiteBalanceBlueRegister") / 255.;
+  } 
+  // the JAI cameras become too slow when reading out the DigitalRed and DigitalBlue values
+  // the white balance is adjusted by adjusting the Gain values for Red and Blue pixels
+  else if (strcmp("JAI Corporation", vendor_name) == 0)
+  {
+    msg.white_balance_red = 1.0;
+    msg.white_balance_green = 1.0;
+    msg.white_balance_blue = 1.0;
+  }
+  // the Basler cameras use the 'BalanceRatioAbs' keyword instead
+  else if (strcmp("Basler", vendor_name) == 0)
+  {
+    arv_device_set_string_feature_value(p_device_, "BalanceRatioSelector", "Red");
+    msg.white_balance_red = arv_device_get_float_feature_value(p_device_, "BalanceRatioAbs");
+    arv_device_set_string_feature_value(p_device_, "BalanceRatioSelector", "Green");
+    msg.white_balance_green = arv_device_get_float_feature_value(p_device_, "BalanceRatioAbs");
+    arv_device_set_string_feature_value(p_device_, "BalanceRatioSelector", "Blue");
+    msg.white_balance_blue = arv_device_get_float_feature_value(p_device_, "BalanceRatioAbs");
+  }
+  // the standard way 
+  else if (implemented_features_["BalanceRatio"] && implemented_features_["BalanceRatioSelector"])
+  {
+    arv_device_set_string_feature_value(p_device_, "BalanceRatioSelector", "Red");
+    msg.white_balance_red = arv_device_get_float_feature_value(p_device_, "BalanceRatio");
+    arv_device_set_string_feature_value(p_device_, "BalanceRatioSelector", "Green");
+    msg.white_balance_green = arv_device_get_float_feature_value(p_device_, "BalanceRatio");
+    arv_device_set_string_feature_value(p_device_, "BalanceRatioSelector", "Blue");
+    msg.white_balance_blue = arv_device_get_float_feature_value(p_device_, "BalanceRatio");
+  }
+
+  if (strcmp("Basler", vendor_name) == 0) {
+    msg.temperature = static_cast<float>(arv_device_get_float_feature_value(p_device_, "TemperatureAbs"));
+  } 
+  else if (implemented_features_["DeviceTemperature"])
+  {
+    msg.temperature = arv_device_get_float_feature_value(p_device_, "DeviceTemperature");
+  }
+
 }
 
 void CameraAravisNodelet::controlLostCallback(ArvDevice *p_gv_device, gpointer can_instance)

--- a/src/camera_aravis_nodelet.cpp
+++ b/src/camera_aravis_nodelet.cpp
@@ -1808,7 +1808,6 @@ void CameraAravisNodelet::discoverFeatures()
 
   std::list<ArvDomNode*> todo;
   todo.push_front((ArvDomNode*)arv_gc_get_node(gc, "Root"));
-  GError *error = NULL;
 
   while (!todo.empty())
   {
@@ -1837,8 +1836,8 @@ void CameraAravisNodelet::discoverFeatures()
       //if (!(ARV_IS_GC_CATEGORY(node) || ARV_IS_GC_ENUM_ENTRY(node) /*|| ARV_IS_GC_PORT(node)*/)) {
       ArvGcFeatureNode *fnode = ARV_GC_FEATURE_NODE(node);
       const std::string fname(arv_gc_feature_node_get_name(fnode));
-      const bool usable = arv_gc_feature_node_is_available(fnode, &error)
-          && arv_gc_feature_node_is_implemented(fnode, &error);
+      const bool usable = arv_gc_feature_node_is_available(fnode, NULL)
+          && arv_gc_feature_node_is_implemented(fnode, NULL);
       ROS_INFO_STREAM("Feature " << fname << " is " << usable);
       implemented_features_.emplace(fname, usable);
       //}


### PR DESCRIPTION
Hello Thomas,

in this PR we added the `extended_camera_info` message, that captures additional information about the camera acquisition process like the exposure time, gain, black level, white balance values and device temperature.
The acquisition-related parameters are not covered in ROS 1 ([ROS REP 104](https://www.ros.org/reps/rep-0104.html#other-camera-settings) also suggests providing this information in a dedicated topic).
This message is only published when the `ExtendedCameraInfo` parameter is set.

Unfortunately, even with the GenICam standard there are not always uniform camera feature names to extract the white balance values. This PR only covers the GenICam cameras that conform the standard, as well as the special feature names used by Basler, JAI and TIS cameras.

The two previous commits remove unnecessary warning messages from aravis when parsing for feature names not available in some cameras and makes sure that the ROI values set in the standard `CameraInfo` are correctly considered, when rectifying a cropped camera image.

Let me know what you think of this PR.

Best regards,
Peter