### PR TITLE
Add Line0 hardware trigger support in ros re-configure 

### DIFF
--- a/cfg/CameraAravis.cfg
+++ b/cfg/CameraAravis.cfg
@@ -20,6 +20,7 @@ acquisitionmode_enum = gen.enum([gen.const("ContinuousFrame",            str_t, 
                                 "AcquisitionMode")
 triggersource_enum  = gen.enum([gen.const("Any",                    str_t, "Any",       "FrameStart triggered via any available method"),
                                 gen.const("Software",               str_t, "Software",  "FrameStart triggered via software"),
+                                gen.const("Line0",                  str_t, "Line0",     "FrameStart triggered via hardware input 0"),
                                 gen.const("Line1",                  str_t, "Line1",     "FrameStart triggered via hardware input 1"),
                                 gen.const("Line2",                  str_t, "Line2",     "FrameStart triggered via hardware input 2") ],
                                 "TriggerSource")


### PR DESCRIPTION
FLIR BlackFly S cameras support Line0 as an option for Hardware Trigger.

This is a trivial change to support selecting Line0 in the re-configure interface