### PR TITLE
Always assume num_streams_ = 1 

### DIFF
--- a/include/camera_aravis/camera_aravis_nodelet.h
+++ b/include/camera_aravis/camera_aravis_nodelet.h
@@ -209,6 +209,16 @@ public:
   virtual ~CameraAravisNodelet();
 
 private:
+  ArvCamera *p_camera_ = NULL;
+  ArvDevice *p_device_ = NULL;
+  gint num_streams_ = 0;
+  std::vector<ArvStream *> p_streams_;
+  std::vector<std::string> stream_names_;
+  bool extended_camera_info_;
+  std::vector<CameraBufferPool::Ptr> p_buffer_pools_;
+  int32_t acquire_ = 0;
+  std::vector<ConversionFunction> convert_formats;
+
   virtual void onInit() override;
   void spawnStream();
 
@@ -310,7 +320,7 @@ protected:
 
   Config config_;
   Config config_min_;
-  Config config_max_;  
+  Config config_max_;
   bool   use_ptp_stamp_;
 
   std::atomic<bool> spawning_;
@@ -349,16 +359,6 @@ protected:
     CameraAravisNodelet* can;
     size_t stream_id;
   };
-
-  ArvCamera *p_camera_ = NULL;
-  ArvDevice *p_device_ = NULL;
-  gint num_streams_;
-  std::vector<ArvStream *> p_streams_;
-  std::vector<std::string> stream_names_;
-  bool extended_camera_info_;
-  std::vector<CameraBufferPool::Ptr> p_buffer_pools_;
-  int32_t acquire_ = 0;
-  std::vector<ConversionFunction> convert_formats;
 };
 
 } // end namespace camera_aravis

--- a/src/camera_aravis_nodelet.cpp
+++ b/src/camera_aravis_nodelet.cpp
@@ -547,12 +547,17 @@ void CameraAravisNodelet::onInit()
   discoverFeatures();
 
   // Check the number of streams for this camera
-  num_streams_ = 0;
   num_streams_ = arv_device_get_integer_feature_value(p_device_, "DeviceStreamChannelCount");
   // if this return 0, try the deprecated GevStreamChannelCount in case this is an older camera
-  if (num_streams_ == 0) {
+  if (!num_streams_) {
     num_streams_ = arv_device_get_integer_feature_value(p_device_, "GevStreamChannelCount");
   }
+  // if this also returns 0, assume number of streams = 1
+  if (!num_streams_) {
+    ROS_WARN("Unable to detect number of supported stream channels.");
+    num_streams_ = 1;
+  }
+
   ROS_INFO("Number of supported stream channels %i.", (int) num_streams_);
 
   std::string stream_channel_args;


### PR DESCRIPTION
Assume num_streams_ = 1 if DeviceStreamChannelCount and GevStreamChannelCount are unavailable

Allows using arv-fake-gv-camera for debugging purposes
Fixes bug mentioned in #9