### PR TITLE
faster read of white balance and black level values for Basler acA2440-20gc & JAI FS-3200D-10GE

### DIFF
--- a/src/camera_aravis_nodelet.cpp
+++ b/src/camera_aravis_nodelet.cpp
@@ -1018,10 +1018,11 @@ bool CameraAravisNodelet::setBooleanFeatureCallback(camera_aravis::set_boolean_f
 
 void CameraAravisNodelet::resetPtpClock()
 {
+  // a PTP slave can take the following states: Slave, Listening, Uncalibrated, Faulty, Disabled
   std::string ptp_status(arv_device_get_string_feature_value(p_device_, "GevIEEE1588Status"));
-  if (ptp_status != std::string("Slave"))
+  if (ptp_status == std::string("Faulty") || ptp_status == std::string("Disabled"))
   {
-    ROS_INFO("camera_aravis: Reset ptp clock");
+    ROS_INFO("camera_aravis: Reset ptp clock (was set to %s)", ptp_status.c_str());
     arv_device_set_boolean_feature_value(p_device_, "GevIEEE1588", false);
     arv_device_set_boolean_feature_value(p_device_, "GevIEEE1588", true);
   }

--- a/src/camera_aravis_nodelet.cpp
+++ b/src/camera_aravis_nodelet.cpp
@@ -1018,11 +1018,10 @@ bool CameraAravisNodelet::setBooleanFeatureCallback(camera_aravis::set_boolean_f
 
 void CameraAravisNodelet::resetPtpClock()
 {
-  // a PTP slave can take the following states: Slave, Listening, Uncalibrated, Faulty, Disabled
   std::string ptp_status(arv_device_get_string_feature_value(p_device_, "GevIEEE1588Status"));
-  if (ptp_status == std::string("Faulty") || ptp_status == std::string("Disabled"))
+  if (ptp_status != std::string("Slave"))
   {
-    ROS_INFO("camera_aravis: Reset ptp clock (was set to %s)", ptp_status.c_str());
+    ROS_INFO("camera_aravis: Reset ptp clock");
     arv_device_set_boolean_feature_value(p_device_, "GevIEEE1588", false);
     arv_device_set_boolean_feature_value(p_device_, "GevIEEE1588", true);
   }


### PR DESCRIPTION
The white balance and black level values for the Basler acA2440-20gc & JAI FS-3200D-10GE can be read more efficiently by reading from the exact memory locations of the camera instead of using the Selector features.

I cannot confirm how stable these optimizations based on exact memory locations are in terms of firmware updates changing the memory location of the specific feature on the camera.

These optimizations are necessary to read out the white balance and black level values of the cameras at 10Hz (especially for the JAI prism camera).