### PR TITLE
fix: only reset PTP clock when in "Faulty" or "Disabled" state

### DIFF
--- a/src/camera_aravis_nodelet.cpp
+++ b/src/camera_aravis_nodelet.cpp
@@ -628,13 +628,15 @@ bool CameraAravisNodelet::setBooleanFeatureCallback(camera_aravis::set_boolean_f
 
 void CameraAravisNodelet::resetPtpClock()
 {
+  // a PTP slave can take the following states: Slave, Listening, Uncalibrated, Faulty, Disabled
   std::string ptp_status(arv_device_get_string_feature_value(p_device_, "GevIEEE1588Status"));
-  if (ptp_status != std::string("Slave"))
+  if (ptp_status == std::string("Faulty") || ptp_status == std::string("Disabled"))
   {
-    ROS_INFO("camera_aravis: Reset ptp clock");
+    ROS_INFO("camera_aravis: Reset ptp clock (was set to %s)", ptp_status.c_str());
     arv_device_set_boolean_feature_value(p_device_, "GevIEEE1588", false);
     arv_device_set_boolean_feature_value(p_device_, "GevIEEE1588", true);
   }
+  
 }
 
 void CameraAravisNodelet::cameraAutoInfoCallback(const CameraAutoInfoConstPtr &msg_ptr)


### PR DESCRIPTION
resetPtpClock() should be called when a camera is an erroneous state.
The old implementation would also reset the PTP slave state, even when the camera was still setting up in the "Listening" state.

The PR makes sure, that the camera is truly reset if it ends up in the state "Faulty" or "Disabled"

[Page 7 of this document](https://tech.ebu.ch/docs/techreview/trev_2019-Q4_PTP_in_Broadcasting_Part_2.pdf) has a float chart of the different states and transitions a PTP slave goes through.